### PR TITLE
Move JSON.parse to try catch

### DIFF
--- a/jsonOddsAPI.js
+++ b/jsonOddsAPI.js
@@ -36,7 +36,7 @@ var JsonOddsAPI = function(token) {
 		};
 		request.get(requestOptions, function (err, response, body) {
 			if (err) return cb(err);
-			if (!body || _.isEmpty(JSON.parse(body))) return cb(null, '');
+			if (!body) return cb(null, '');
 			parse(body, function(err, parsed) {
 				if (err) return cb(err);
 				cb(null, response, parsed);
@@ -61,6 +61,7 @@ var JsonOddsAPI = function(token) {
 	var parse = function(body, cb) {
 		try {
 			var result = JSON.parse(body);
+			if (_.isEmpty(result)) return cb(null, '');
 			return cb(null, result);
 		}
 		catch(e){


### PR DESCRIPTION
Hi I also encountered this issue - https://github.com/sbefort/json-odds-api/issues/1

To fix I moved the JSON.parse to the try catch in the custom parse function so that I could handle the error more gracefully.

I have also reach out to JsonOdds
